### PR TITLE
fix typo "Intsrument" in fixture

### DIFF
--- a/autoreduce_scripts/autoreduce_django/fixtures/multiple_instruments_and_runs.json
+++ b/autoreduce_scripts/autoreduce_django/fixtures/multiple_instruments_and_runs.json
@@ -78,7 +78,7 @@
         "pk": 1,
         "model": "reduction_viewer.datalocation",
         "fields": {
-            "file_path": "/isis/NDXTestInstrument/Intsrument/data/cycle_21_1/TEST99999.nxs",
+            "file_path": "/isis/NDXTestInstrument/Instrument/data/cycle_21_1/TEST99999.nxs",
             "reduction_run_id": 1
         }
     },


### PR DESCRIPTION
### Summary of work
Fix "Intsrument" typo to "Instrument"