### PR TITLE
bump h5py version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "autoreduce_utils==22.0.0.dev11",
         "django",  # will be matched with requirement in autoreduce_db
         "fire==0.4.0",
-        "h5py==3.1.0",  # for reading the RB number from the datafile
+        "h5py<=3.6.0",  # for reading the RB number from the datafile
         "GitPython<=3.1.26",  # for backup_reduction_scripts.py
         "stomp.py==7.0.0"
     ],


### PR DESCRIPTION
### Summary of work
Bump h5py with <= version to support Python 3.6 and 3.8